### PR TITLE
Make rust2018 compatible

### DIFF
--- a/macros/examples/generic-trait-bounds.rs
+++ b/macros/examples/generic-trait-bounds.rs
@@ -1,0 +1,69 @@
+extern crate serde;
+extern crate jsonrpc_core;
+#[macro_use]
+extern crate jsonrpc_macros;
+
+use serde::de::DeserializeOwned;
+use jsonrpc_core::{IoHandler, Error, Result};
+use jsonrpc_core::futures::future::{self, FutureResult};
+
+// Two only requires DeserializeOwned
+build_rpc_trait! {
+	pub trait Rpc<One> where
+		Two: DeserializeOwned,
+	{
+		/// Get One type.
+		#[rpc(name = "getOne")]
+		fn one(&self) -> Result<One>;
+
+		/// Adds two numbers and returns a result
+		#[rpc(name = "setTwo")]
+		fn set_two(&self, Two) -> Result<()>;
+
+		/// Performs asynchronous operation
+		#[rpc(name = "beFancy")]
+		fn call(&self, One) -> FutureResult<(One, u64), Error>;
+	}
+}
+
+build_rpc_trait! {
+	pub trait Rpc2<> where
+		Two: DeserializeOwned,
+	{
+		/// Adds two numbers and returns a result
+		#[rpc(name = "setTwo")]
+		fn set_two(&self, Two) -> Result<()>;
+	}
+}
+
+struct RpcImpl;
+
+impl Rpc<u64, String> for RpcImpl {
+	fn one(&self) -> Result<u64> {
+		Ok(100)
+	}
+
+	fn set_two(&self, x: String) -> Result<()> {
+		println!("{}", x);
+		Ok(())
+	}
+
+	fn call(&self, num: u64) -> FutureResult<(u64, u64), Error> {
+		::future::finished((num + 999, num))
+	}
+}
+
+impl Rpc2<String> for RpcImpl {
+	fn set_two(&self, _: String) -> Result<()> {
+		unimplemented!()
+	}
+}
+
+
+fn main() {
+	let mut io = IoHandler::new();
+
+	io.extend_with(Rpc::to_delegate(RpcImpl));
+	io.extend_with(Rpc2::to_delegate(RpcImpl));
+}
+

--- a/macros/src/auto_args.rs
+++ b/macros/src/auto_args.rs
@@ -188,12 +188,14 @@ macro_rules! build_rpc_trait {
 				)*
 			);
 
-			$(
-				$(#[doc=$sub_doc])*
-				fn $sub_name ( $($sub_p)* );
-				$(#[doc=$unsub_doc])*
-				fn $unsub_name ( $($unsub_p)* ) -> $sub_result <$sub_out $(, $error_unsub)* >;
-			)*
+			build_rpc_trait!(GENERATE_FUNCTIONS
+				$(
+					$(#[doc=$sub_doc])*
+					fn $sub_name ( $( $sub_p )* );
+					$(#[doc=$unsub_doc])*
+					fn $unsub_name ( $( $unsub_p )* ) -> $sub_result <$sub_out $(, $error_unsub) *>;
+				)*
+			);
 
 			/// Transform this into an `IoDelegate`, automatically wrapping
 			/// the parameters.
@@ -227,12 +229,12 @@ macro_rules! build_rpc_trait {
 	(GENERATE_FUNCTIONS
 		$(
 			$( #[doc=$m_doc:expr] )*
-			fn $m_name: ident (&self $(, $p: ty)* ) -> $result: ty;
+			fn $m_name: ident (&self $(, $p: ty)* ) $( -> $result: ty)*;
 		)*
 	) => {
 		$(
 			$(#[doc=$m_doc])*
-			fn $m_name (&self $(, _: $p )* ) -> $result;
+			fn $m_name (&self $(, _: $p )* ) $( -> $result)*;
 		)*
 	};
 


### PR DESCRIPTION
I honestly have no idea if this does exactly what we need to or not. What I did was to filter out all commits that affected `macros/src/auto_args.rs` commited from when we forked and up until after the Rust2018 fix PR. Then I cherry-picked those.

They applied cleanly, and it seems to work when I depend on this fork in our VPN app :man_shrugging: 